### PR TITLE
Updated value substitution for unfulfilled parameters

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,6 +77,15 @@ const updateActionWithAnswers = (action, answers) => {
         Object.keys(answers).forEach((param) => {
             value = value.replace("{" + param + "}", answers[param])
         })
+
+        // Check if value is an unfulfilled parameter
+        // and substitute with null for better semantics
+        const re = /\{.*\}/
+        const match = value.match(re)
+        if (match) {
+            return null
+        }
+
         return value
     })
 }
@@ -113,6 +122,12 @@ const optionDefinitions = [{
         type: Boolean,
         defaultValue: false,
         description: 'Make more noise'
+    }, {
+        name: 'debug',
+        alias: 'd',
+        type: Boolean,
+        defaultValue: false,
+        description: 'Debug mode to omit things like running the action.'
     },
 ]
 
@@ -144,7 +159,8 @@ const run = async () => {
     try {
         const answers = await askQuestions(flow.questions)
         const action = updateActionWithAnswers(flow.action, answers)
-        if (params.verbose) console.log('Performing action...\n' + JSON.stringify(action))
+        if (params.verbose) console.log('Performing action...\n' + JSON.stringify(action, null, 2))
+        if (params.debug) { process.exit(0) }
         const result = await performAction(action)
         const response = result.res
         console.log('Response: ' + response.statusCode + ' ' + response.statusMessage + '\n' + response.text)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cli-invoke",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "cli-invoke will ask questions defined in a configuration file and invoke a web hook based on your answers",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
Unfulfilled parameters will now be `null` to make semantics more clear on the receiving end to avoid knowledge of cli-invoke's format when conditional parameters are left out.