### PR TITLE
Updated value substitution for unfulfilled parameters

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cli-invoke",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "cli-invoke will ask questions defined in a configuration file and invoke a web hook based on your answers",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
- Unfulfilled parameters will now be substituted with the default value if it's present. This makes it easier to handle cases where a question is omitted in a way that is flexible and allows the parameter to be handled on both sender and the receiver's end. The sender can now default the value or let the receiver handle the case when the value is equal to `{QUESTION}` or ideally `{KEY}`.
- Added new option `debug` to better run the cli without executing the action.